### PR TITLE
Only add sessionHeader if it is set.

### DIFF
--- a/soapclient/SforceBaseClient.php
+++ b/soapclient/SforceBaseClient.php
@@ -219,9 +219,10 @@ class SforceBaseClient {
 	private function setHeaders($call=NULL) {
 		$this->sforce->__setSoapHeaders(NULL);
 		
-		$header_array = array (
-			$this->sessionHeader
-		);
+		$header_array = array ();
+		if ($this->sessionHeader != NULL) {
+			array_push($header_array, $this->sessionHeader);
+		};
 
 		$header = $this->callOptions;
 		if ($header != NULL) {


### PR DESCRIPTION
With invalid credentials the sessionHeader is set to NULL and calling __setHeaders() on SoapClient results in a fatal error.